### PR TITLE
Support for multiple repositories

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
 	"id": "github-issue-augmentation",
 	"name": "GitHub Issue Augmentation",
-	"version": "0.0.2",
+	"version": "0.1.0",
 	"minAppVersion": "0.15.0",
 	"description": "Augments GitHub issue IDs",
 	"author": "samprintz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1380,6 +1380,14 @@
 				"queue-microtask": "^1.2.2"
 			}
 		},
+		"rxjs": {
+			"version": "7.8.1",
+			"resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.1.tgz",
+			"integrity": "sha512-AA3TVj+0A2iuIoQkWEK/tqFjBq2j+6PO6Y0zJcvzLAFhEFIO3HL0vls9hWLncZbAAbK0mar7oZ4V079I/qPMxg==",
+			"requires": {
+				"tslib": "^2.1.0"
+			}
+		},
 		"semver": {
 			"version": "7.4.0",
 			"resolved": "https://registry.npmjs.org/semver/-/semver-7.4.0.tgz",
@@ -1464,8 +1472,7 @@
 		"tslib": {
 			"version": "2.4.0",
 			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-			"integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
-			"dev": true
+			"integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
 		},
 		"tsutils": {
 			"version": "3.21.0",

--- a/package.json
+++ b/package.json
@@ -24,5 +24,8 @@
 		"obsidian": "latest",
 		"tslib": "2.4.0",
 		"typescript": "4.7.4"
+	},
+	"dependencies": {
+		"rxjs": "^7.8.1"
 	}
 }

--- a/src/issue-widget.ts
+++ b/src/issue-widget.ts
@@ -6,12 +6,13 @@ export class IssueWidget extends WidgetType {
         this.issueId = issue.id;
         this.issueUrl = issue.url;
         this.issueTitle = issue.title;
+        this.broken = issue.broken;
     }
 
     toDOM(view: EditorView): HTMLElement {
         const span = document.createElement("span");
 
-        if (this.issueTitle) {
+        if (!this.broken) {
             const whitespace = document.createTextNode(" ");
 
             const a = document.createElement("a");
@@ -21,6 +22,10 @@ export class IssueWidget extends WidgetType {
 
             span.appendChild(whitespace);
             span.appendChild(a);
+        } else {
+            const warning = document.createTextNode("?")
+            span.classList.add("invalid-issue-id");
+            span.appendChild(warning)
         }
 
         return span;

--- a/src/main.ts
+++ b/src/main.ts
@@ -143,7 +143,7 @@ export default class IssueAugmentationPlugin extends Plugin {
 	async getFileIssueTitles(path: string) {
 		const map = {};
 
-		const defaultRepository = this.settings.repoNames[0];
+		const defaultRepository = this.settings.defaultRepoName;
 		const regex = /(([a-zA-Z0-9\\.\-_]*)#)?(\d{1,5}),(.*)/g;
 
 		console.log(`Read issue titles from ${path}`);

--- a/src/main.ts
+++ b/src/main.ts
@@ -161,16 +161,21 @@ export default class IssueAugmentationPlugin extends Plugin {
 				const match = regex.exec(row);
 
 				if (match) {
-					// TODO warn if no default repository is specified in settings
-					const repository = match[2] ?? defaultRepository;
-					const issueId = match[3];
-					const text = match[4];
+					const hasValidRepository = match[2] || defaultRepository;
 
-					if (!map.hasOwnProperty(repository)) {
-						map[repository] = {};
+					if (hasValidRepository) {
+						const repository = match[2] ?? defaultRepository;
+						const issueId = match[3];
+						const text = match[4];
+
+						if (!map.hasOwnProperty(repository)) {
+							map[repository] = {};
+						}
+
+						map[repository][issueId] = text;
+					} else {
+						console.warn(`Skipping row ${rowIndex} in CSV without repository: ${row}. Specify repository or enter a default repository in settings.`);
 					}
-
-					map[repository][issueId] = text;
 				} else {
 					console.warn(`Skipping invalid row ${rowIndex} in CSV: ${row}`);
 				}

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -84,7 +84,24 @@ export class IssueAugmentationPluginSettingTab extends PluginSettingTab {
 			.addText(text => text
 				.setValue(this.plugin.settings.repoNames?.join(","))
 				.onChange(async (value) => {
-					this.plugin.settings.repoNames = value?.split(","); // TODO validate
+					const repoNames = []
+
+					if (value?.length > 0) {
+						const inputValues = value.split(",");
+						const regex = /^[a-zA-Z0-9\\.\-_]+$/;
+
+						for (const inputValue of inputValues) {
+							regex.lastIndex = 0;
+							const match = regex.exec(inputValue);
+							if (match) {
+								repoNames.push(inputValue);
+							} else {
+								console.warn(`Invalid repository name: ${inputValue}`);
+							}
+						}
+					}
+
+					this.plugin.settings.repoNames = repoNames;
 					await this.plugin.saveSettings();
 					this.reloadIssueIdToTitleMapSubject.next(value);
 				})

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -63,18 +63,18 @@ export class IssueAugmentationPluginSettingTab extends PluginSettingTab {
 				.onChange(async (value) => {
 					this.plugin.settings.repoOwner = value;
 					await this.plugin.saveSettings();
-					this.plugin.reloadIssueIdToTitleMap();
+					this.plugin.reloadIssueIdToTitleMap(); // TODO debounce time (rxjs)?
 				})
 			);
 
 		new Setting(containerEl)
-			.setName('GitHub repository name')
+			.setName('GitHub repositories (comma-separated; first is default)')
 			.addText(text => text
-				.setValue(this.plugin.settings.repoName)
+				.setValue(this.plugin.settings.repoNames?.join(","))
 				.onChange(async (value) => {
-					this.plugin.settings.repoName = value;
+					this.plugin.settings.repoNames = value?.split(","); // TODO validate
 					await this.plugin.saveSettings();
-					this.plugin.reloadIssueIdToTitleMap();
+					this.plugin.reloadIssueIdToTitleMap(); // TODO debounce time (rxjs)?
 				})
 			);
 
@@ -86,7 +86,7 @@ export class IssueAugmentationPluginSettingTab extends PluginSettingTab {
 				.onChange(async (value) => {
 					this.plugin.settings.githubToken = value;
 					await this.plugin.saveSettings();
-					this.plugin.reloadIssueIdToTitleMap();
+					this.plugin.reloadIssueIdToTitleMap(); // TODO debounce time (rxjs)?
 				})
 			);
 

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -1,5 +1,7 @@
 import { App, PluginSettingTab, Setting } from 'obsidian';
 import IssueAugmentationPlugin from 'main';
+import { Subject } from 'rxjs';
+import { debounceTime, tap } from "rxjs/operators";
 
 
 export interface IssueAugmentationPluginSettings {
@@ -27,6 +29,16 @@ export class IssueAugmentationPluginSettingTab extends PluginSettingTab {
 	constructor(app: App, plugin: IssueAugmentationPlugin) {
 		super(app, plugin);
 		this.plugin = plugin;
+
+		this.reloadIssueIdToTitleMapSubject = new Subject();
+		this.reloadIssueIdToTitleMapSubject
+			.pipe(
+				debounceTime(2000),
+				tap((v) => {
+					this.plugin.reloadIssueIdToTitleMap();
+				})
+			)
+			.subscribe();
 	}
 
 	display(): void {
@@ -52,7 +64,7 @@ export class IssueAugmentationPluginSettingTab extends PluginSettingTab {
 				.onChange(async (value) => {
 					this.plugin.settings.urlPrefix = value;
 					await this.plugin.saveSettings();
-					this.plugin.reloadEditorExtensions();
+					this.reloadIssueIdToTitleMapSubject.next(value);
 				})
 			);
 
@@ -63,7 +75,7 @@ export class IssueAugmentationPluginSettingTab extends PluginSettingTab {
 				.onChange(async (value) => {
 					this.plugin.settings.repoOwner = value;
 					await this.plugin.saveSettings();
-					this.plugin.reloadIssueIdToTitleMap(); // TODO debounce time (rxjs)?
+					this.reloadIssueIdToTitleMapSubject.next(value);
 				})
 			);
 
@@ -74,7 +86,7 @@ export class IssueAugmentationPluginSettingTab extends PluginSettingTab {
 				.onChange(async (value) => {
 					this.plugin.settings.repoNames = value?.split(","); // TODO validate
 					await this.plugin.saveSettings();
-					this.plugin.reloadIssueIdToTitleMap(); // TODO debounce time (rxjs)?
+					this.reloadIssueIdToTitleMapSubject.next(value);
 				})
 			);
 
@@ -86,7 +98,7 @@ export class IssueAugmentationPluginSettingTab extends PluginSettingTab {
 				.onChange(async (value) => {
 					this.plugin.settings.githubToken = value;
 					await this.plugin.saveSettings();
-					this.plugin.reloadIssueIdToTitleMap(); // TODO debounce time (rxjs)?
+					this.reloadIssueIdToTitleMapSubject.next(value);
 				})
 			);
 

--- a/src/view-plugin.ts
+++ b/src/view-plugin.ts
@@ -60,6 +60,7 @@ function decosByLineToDecorationSet(view: EditorView, decorationsByLine: {[lineN
             ? plugin.settings.urlPrefix
             : plugin.settings.urlPrefix + "/";
     const defaultRepository = plugin.settings.defaultRepoName;
+    const repositoryOwner = plugin.settings.repoOwner;
 
     for (const lineNumber of Object.keys(decorationsByLine)) {
         const widgets = decorationsByLine[lineNumber];
@@ -75,7 +76,7 @@ function decosByLineToDecorationSet(view: EditorView, decorationsByLine: {[lineN
             })
             .filter(issue => plugin.issueIdToTitleMap.hasOwnProperty(issue.repository)) // invalid repository name // TODO highlight as invalid
             .map((issue => {
-                issue.url = `${urlPrefix}${issue.repository}/${issue.id}`;
+                issue.url = `${urlPrefix}${repositoryOwner}/${issue.repository}/issues/${issue.id}`;
                 issue.title = plugin.issueIdToTitleMap[issue.repository][issue.id];
 
                 return Decoration

--- a/src/view-plugin.ts
+++ b/src/view-plugin.ts
@@ -33,7 +33,7 @@ function getDecosOnLine(view: EditorView, lineNumber: number) {
     const line = view.state.doc.line(lineNumber);
     const docText = view.state.sliceDoc(line.from, line.to);
 
-    const regex = /#(\d{3,4})/g;
+    const regex = /#(\d{1,5})/g;
 
     const matches = [...docText.matchAll(regex)];
 

--- a/src/view-plugin.ts
+++ b/src/view-plugin.ts
@@ -68,16 +68,20 @@ function decosByLineToDecorationSet(view: EditorView, decorationsByLine: {[lineN
 
         const offsetWidgets = widgets
             .map((issue) => {
-                // TODO ignore if no default repository is specified in settings
                 issue.repository = issue.repository?.length
                         ? issue.repository
                         : defaultRepository;
                 return issue;
             })
-            .filter(issue => plugin.issueIdToTitleMap.hasOwnProperty(issue.repository)) // invalid repository name // TODO highlight as invalid
             .map((issue => {
-                issue.url = `${urlPrefix}${repositoryOwner}/${issue.repository}/issues/${issue.id}`;
-                issue.title = plugin.issueIdToTitleMap[issue.repository][issue.id];
+                if (plugin.issueIdToTitleMap.hasOwnProperty(issue.repository)) {
+                    issue.url = `${urlPrefix}${repositoryOwner}/${issue.repository}/issues/${issue.id}`;
+                    issue.title = plugin.issueIdToTitleMap[issue.repository][issue.id];
+                } else { // invalid repository name
+                    issue.url = "";
+                    issue.title = "";
+                    issue.broken = true;
+                }
 
                 return Decoration
                     .widget({

--- a/src/view-plugin.ts
+++ b/src/view-plugin.ts
@@ -67,6 +67,7 @@ function decosByLineToDecorationSet(view: EditorView, decorationsByLine: {[lineN
 
         const offsetWidgets = widgets
             .map((issue) => {
+                // TODO ignore if no default repository is specified in settings
                 issue.repository = issue.repository?.length
                         ? issue.repository
                         : defaultRepository;

--- a/src/view-plugin.ts
+++ b/src/view-plugin.ts
@@ -77,17 +77,14 @@ function decosByLineToDecorationSet(view: EditorView, decorationsByLine: {[lineN
                 if (plugin.issueIdToTitleMap.hasOwnProperty(issue.repository)) {
                     issue.url = `${urlPrefix}${repositoryOwner}/${issue.repository}/issues/${issue.id}`;
                     issue.title = plugin.issueIdToTitleMap[issue.repository][issue.id];
+                    return Decoration
+                        .widget({ widget: new IssueWidget(issue) })
+                        .range(issue.end + lineStart);
                 } else { // invalid repository name
-                    issue.url = "";
-                    issue.title = "";
-                    issue.broken = true;
+                    return Decoration
+                        .mark({ class: 'invalid-issue-id' })
+                        .range(issue.start + lineStart, issue.end + lineStart);
                 }
-
-                return Decoration
-                    .widget({
-                        widget: new IssueWidget(issue)
-                    })
-                    .range(issue.end + lineStart);
             }));
 
         allWidgets.push(...offsetWidgets);

--- a/src/view-plugin.ts
+++ b/src/view-plugin.ts
@@ -56,7 +56,9 @@ function decosByLineToDecorationSet(view: EditorView, decorationsByLine: {[lineN
     // TODO better way to access settings/plugin properties
     const plugin = window.app.plugins.plugins['github-issue-augmentation'];
 
-    const urlPrefix = plugin.settings.urlPrefix.endsWith("/") ? plugin.settings.urlPrefix : plugin.settings.urlPrefix + "/";
+    const urlPrefix = plugin.settings.urlPrefix.endsWith("/")
+            ? plugin.settings.urlPrefix
+            : plugin.settings.urlPrefix + "/";
     const defaultRepository = plugin.settings.repoNames[0];
 
     for (const lineNumber of Object.keys(decorationsByLine)) {
@@ -64,21 +66,23 @@ function decosByLineToDecorationSet(view: EditorView, decorationsByLine: {[lineN
         const lineStart = view.state.doc.line(lineNumber).from;
 
         const offsetWidgets = widgets
-        .map((issue) => {
-            issue.repository = issue.repository?.length ? issue.repository : defaultRepository;
-            return issue;
-        })
-        .filter(issue => plugin.issueIdToTitleMap.hasOwnProperty(issue.repository)) // invalid repository name // TODO highlight as invalid
-        .map((issue => {
-            issue.url = `${urlPrefix}${issue.repository}/${issue.id}`;
-            issue.title = plugin.issueIdToTitleMap[issue.repository][issue.id];
+            .map((issue) => {
+                issue.repository = issue.repository?.length
+                        ? issue.repository
+                        : defaultRepository;
+                return issue;
+            })
+            .filter(issue => plugin.issueIdToTitleMap.hasOwnProperty(issue.repository)) // invalid repository name // TODO highlight as invalid
+            .map((issue => {
+                issue.url = `${urlPrefix}${issue.repository}/${issue.id}`;
+                issue.title = plugin.issueIdToTitleMap[issue.repository][issue.id];
 
-            return Decoration
-                .widget({
-                    widget: new IssueWidget(issue)
-                })
-                .range(issue.end + lineStart);
-        }));
+                return Decoration
+                    .widget({
+                        widget: new IssueWidget(issue)
+                    })
+                    .range(issue.end + lineStart);
+            }));
 
         allWidgets.push(...offsetWidgets);
     }

--- a/src/view-plugin.ts
+++ b/src/view-plugin.ts
@@ -59,7 +59,7 @@ function decosByLineToDecorationSet(view: EditorView, decorationsByLine: {[lineN
     const urlPrefix = plugin.settings.urlPrefix.endsWith("/")
             ? plugin.settings.urlPrefix
             : plugin.settings.urlPrefix + "/";
-    const defaultRepository = plugin.settings.repoNames[0];
+    const defaultRepository = plugin.settings.defaultRepoName;
 
     for (const lineNumber of Object.keys(decorationsByLine)) {
         const widgets = decorationsByLine[lineNumber];

--- a/styles.css
+++ b/styles.css
@@ -2,3 +2,9 @@
     color: var(--text-faint);
     text-decoration: none;
 }
+
+.invalid-issue-id {
+    color: var(--red);
+    text-decoration: underline;
+    text-decoration-style: dotted;
+}


### PR DESCRIPTION
- Closes #1. Multiple repositories can be listed in the settings now. If no repository is specified before an issue ID (e.g. `#1234` instead of `myrepo#1234`), a default repository can be specified in the settings.
- Add debounce time for setting updates before re-fetching issues (using [rxjs](https://rxjs.dev/))
- Add dynamic repository issue counting (using GitHub search API)
- Add highlighting for issue IDs where no title was found due to a missing or invalid repository name